### PR TITLE
[update] csファイルは例外的に必ず含めるように

### DIFF
--- a/Assets/SymphonyFrameWork/Editor/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
+++ b/Assets/SymphonyFrameWork/Editor/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
@@ -299,7 +299,7 @@ namespace SymphonyFrameWork.Editor
                 // AssetStoreToolsは除外して依存関係を追う
                 if (!string.IsNullOrEmpty(normalizedExcludedRootPath)
                     && (path.Equals(normalizedExcludedRootPath, StringComparison.Ordinal)
-                       || path.StartsWith(normalizedExcludedRootPath + "/", StringComparison.Ordinal)))
+                        || path.StartsWith(normalizedExcludedRootPath + "/", StringComparison.Ordinal)))
                 {
                     continue;
                 }
@@ -332,7 +332,8 @@ namespace SymphonyFrameWork.Editor
                 .ToArray();
 
             return allFiles
-                .Where(usedAssetPaths.Contains)
+                .Where(files => usedAssetPaths.Contains(files)
+                                || files.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
                 .ToArray();
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * アセット依存関係の追跡結果に含まれない `.cs` ファイルが正しく返却対象に追加されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->